### PR TITLE
[PVPLUS-3738] Android - BasicSDK & ProSDK remote bypass function doesn't work

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     /**
      * Pivo pod controller dependencies
      */
-    implementation "app.pivo.android.basicsdk:basicsdk:1.3.6"
+    implementation "app.pivo.android.basicsdk:basicsdk:1.4.1"
 
     /**
      * Pivo Pro SDK dependencie

--- a/app/src/main/java/app/pivo/android/prosdkdemo/PivoControllerActivity.kt
+++ b/app/src/main/java/app/pivo/android/prosdkdemo/PivoControllerActivity.kt
@@ -133,13 +133,13 @@ class PivoControllerActivity : AppCompatActivity() {
         PivoEventBus.subscribe(
             PivoEventBus.REMOTE_CONTROLLER, this, Consumer {
                 when(it){
-                    is PivoEvent.RCCamera->binding.notificationView.text = "CAMERA state: ${if(it.state==0)"Press" else "Release"}"
-                    is PivoEvent.RCMode->binding.notificationView.text = "MODE: ${if(it.state==0)"Press" else "Release"}"
-                    is PivoEvent.RCStop->binding.notificationView.text = "STOP: ${if(it.state==0)"Press" else "Release"}"
-                    is PivoEvent.RCRightContinuous->binding.notificationView.text = "RIGHT_CONTINUOUS: ${if(it.state==0)"Press" else "Release"}"
-                    is PivoEvent.RCLeftContinuous->binding.notificationView.text = "LEFT_CONTINUOUS: ${if(it.state==0)"Press" else "Release"}"
-                    is PivoEvent.RCLeft->binding.notificationView.text = "LEFT: ${if(it.state==0)"Press" else "Release"}"
-                    is PivoEvent.RCRight->binding.notificationView.text = "RIGHT: ${if(it.state==0)"Press" else "Release"}"
+                    is PivoEvent.RCCamera->binding.notificationView.text = "CAMERA state: ${if(it.state==0)"Release" else "Press"}"
+                    is PivoEvent.RCMode->binding.notificationView.text = "MODE: ${if(it.state==0)"Release" else "Press"}"
+                    is PivoEvent.RCStop->binding.notificationView.text = "STOP: ${if(it.state==0)"Release" else "Press"}"
+                    is PivoEvent.RCRightContinuous->binding.notificationView.text = "RIGHT_CONTINUOUS: ${if(it.state==0)"Release" else "Press"}"
+                    is PivoEvent.RCLeftContinuous->binding.notificationView.text = "LEFT_CONTINUOUS: ${if(it.state==0)"Release" else "Press"}"
+                    is PivoEvent.RCLeft->binding.notificationView.text = "LEFT: ${if(it.state==0)"Release" else "Press"}"
+                    is PivoEvent.RCRight->binding.notificationView.text = "RIGHT: ${if(it.state==0)"Release" else "Press"}"
 
                     /**
                      * This below events're deprecated
@@ -154,7 +154,7 @@ class PivoControllerActivity : AppCompatActivity() {
                     is PivoEvent.RCSpeedDownRelease->binding.notificationView.text = "SPEED_DOWN_RELEASE: ${it.level}"
                      */
 
-                    is PivoEvent.RCSpeed->binding.notificationView.text = "SPEED: : ${if(it.state==0)"Press" else "Release"} speed: ${it.level}"
+                    is PivoEvent.RCSpeed->binding.notificationView.text = "SPEED: : ${if(it.state==0)"Release" else "Press"} speed: ${it.level}"
                 }
             })
         //subscribe to name change event

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,6 @@
     <string name="camera">Go camera</string>
     <string name="camera1">Go camera 1</string>
     <string name="camera2">Go camera 2</string>
-    <string name="enable_bypass">Enable Bypass</string>
-    <string name="disable_bypass">Disable Bypass</string>
+    <string name="enable_bypass">Disable Remote Control</string>
+    <string name="disable_bypass">Enable Remote Control</string>
 </resources>


### PR DESCRIPTION
## Related Tickets
> Write A Ticket Number With Link
> On Feature/Hotfix, Use One Ticket Issue that related in.
> On Release, Write All Tickets that implemented in this branch
> e.x : [PVPLUS-1111](https://3iai.atlassian.net/browse/PVPLUS-1111)
- Related Ticket : [PVPLUS-3738](https://3iai.atlassian.net/browse/PVPLUS-3738)

## Merged Versions
> Set Version ( Synced with JIRA )
- 

## Description
> Describe the PR
- Update remote control button text and upgrade Basic SDK to 1.4.1
- Fix remote controller's press/release message handling
